### PR TITLE
Retain additional type parameter of ParseOps tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ All parsing logic lives in `basil.parser.JsonParse`, I tried to be generic here,
 
 ### Next
 
-* Handle escape char
-* Handle whitespace
 * Solve problem of type widening with Fix (maybe Free will help?)
+* Better error message
 * Support Array[Char]
 * Support auto decoding of case classes
 * Stack safety

--- a/src/main/scala/basil/data/ExpectedTerminator.scala
+++ b/src/main/scala/basil/data/ExpectedTerminator.scala
@@ -1,5 +1,15 @@
 package basil.data
 
+/**
+  * ADT to represent expected terminator when parsing json
+  * it's only use when decoding number because number does not
+  * comes with native terminator
+  *
+  * eg. it's evident that `"halo"` is a complete string,
+  *     and `"halo` is not, but we cannot do the same for number
+  *     `2000` and `20000` both can be incomplete
+  *     depending on the subsequent characters
+  */
 sealed trait ExpectedTerminator
 case object Comma                             extends ExpectedTerminator
 case object Bracket                           extends ExpectedTerminator

--- a/src/main/scala/basil/data/HFix.scala
+++ b/src/main/scala/basil/data/HFix.scala
@@ -1,6 +1,5 @@
 package basil.data
 
-import basil.data.HFix.HAlgebra
 import cats.~>
 
 /**
@@ -16,11 +15,29 @@ trait HFunctor[F[_[_], _]] {
   def hfmap[M[_], N[_]](nt: M ~> N): F[M, ?] ~> F[N, ?]
 }
 
-object HFunctor {
+/**
+  * In  :: fT => T
+  * Out :: T => fT
+  */
+case class HFix[F[_[_], _], I](unfix: F[HFix[F, ?], I])
+object HFix {
   type HAlgebra[F[_[_], _], G[_]] = F[G, ?] ~> G
+
+  final implicit class HFunctorOps[F[_[_], _], M[_], A](val fa: F[M, A])(implicit F: HFunctor[F]) {
+    def hfmap[N[_]](nt: M ~> N): F[N, A] = F.hfmap(nt)(fa)
+  }
+
+  def cata[F[_[_], _], I, G[_]](hfix: HFix[F, I], alg: HAlgebra[F, G])(
+      implicit HFunctor: HFunctor[F]): G[I] = {
+    val unpacked: F[HFix[F, ?], I] = hfix.unfix
+    val r = unpacked.hfmap(
+      new (HFix[F, ?] ~> G) {
+        override def apply[A](fa: HFix[F, A]): G[A] = {
+          cata[F, A, G](fa, alg)
+        }
+      }
+    )
+    alg(r)
+  }
 }
 
-case class HFix1[F[_[_], _], I](unfix: F[HFix1[F, ?], I])
-object HFix1 {
-  
-}

--- a/src/main/scala/basil/data/HFix.scala
+++ b/src/main/scala/basil/data/HFix.scala
@@ -1,0 +1,26 @@
+package basil.data
+
+import basil.data.HFix.HAlgebra
+import cats.~>
+
+/**
+  * Copied from `xenomorph` project
+  *
+  * Core concept: F[_[_], _] => ((* -> *) -> *) -> *
+  */
+/**
+  * Higher functor provides ability to
+  * @tparam F
+  */
+trait HFunctor[F[_[_], _]] {
+  def hfmap[M[_], N[_]](nt: M ~> N): F[M, ?] ~> F[N, ?]
+}
+
+object HFunctor {
+  type HAlgebra[F[_[_], _], G[_]] = F[G, ?] ~> G
+}
+
+case class HFix1[F[_[_], _], I](unfix: F[HFix1[F, ?], I])
+object HFix1 {
+  
+}

--- a/src/main/scala/basil/data/PPath.scala
+++ b/src/main/scala/basil/data/PPath.scala
@@ -2,6 +2,15 @@ package basil.data
 
 import cats.Show
 
+/**
+  * ADT to represent the position of parsing
+  * mainly for error reporting
+  *
+  * Right now it just show the path we are `trying` to parse
+  *
+  * But the decoder actually perform parsing and skipping,
+  * we should look into incorporating information of skipping into it
+  */
 sealed trait PPath
 
 /**

--- a/src/main/scala/basil/data/ParseOps.scala
+++ b/src/main/scala/basil/data/ParseOps.scala
@@ -1,9 +1,6 @@
 package basil.data
 
-import cats.data.Const
-import cats.syntax.functor._
-import cats.{Applicative, Eval, Show, Traverse}
-import schemes._
+import cats.~>
 
 /**
   * Potentially recursive tree to represent data that's needed
@@ -11,72 +8,35 @@ import schemes._
   *
   * todo: support sequence
   */
-sealed trait ParseOps[+A]
+sealed trait ParseOps[+F[_], I]
 
-case object GetString                       extends ParseOps[Nothing]
-case object GetBool                         extends ParseOps[Nothing]
-case class GetNum(term: ExpectedTerminator) extends ParseOps[Nothing]
-case class GetNullable[A](ops: A)           extends ParseOps[A]
-case class GetN[A](n: Int, next: A)         extends ParseOps[A]
-case class GetKey[A](key: String, next: A)  extends ParseOps[A]
+case object GetString                             extends ParseOps[Nothing, String]
+case object GetBool                               extends ParseOps[Nothing, Boolean]
+final case class GetNum(term: ExpectedTerminator) extends ParseOps[Nothing, Double]
+final case class GetNullable[F[_], I](ops: F[I]) extends ParseOps[F, Option[I]] {
+  def toG[G[_]](nt: F ~> G): GetNullable[G, I] = GetNullable(nt(ops))
+}
+final case class GetN[F[_], I](n: Int, next: F[I])        extends ParseOps[F, I]
+final case class GetKey[F[_], I](key: String, next: F[I]) extends ParseOps[F, I]
 
 object ParseOps {
-  implicit val traversable: Traverse[ParseOps] = new Traverse[ParseOps] {
-    override def traverse[G[_], A, B](fa: ParseOps[A])(f: A => G[B])(
-        implicit AG: Applicative[G]): G[ParseOps[B]] = {
-      fa match {
-        case GetString      => AG.point(GetString)
-        case g: GetNum      => AG.point(g)
-        case GetBool        => AG.point(GetBool)
-        case GetNullable(a) => f(a).map(GetNullable.apply)
-        case GetN(n, a)     => f(a).map(b => GetN(n, b))
-        case GetKey(k, a)   => f(a).map(b => GetKey(k, b))
+  implicit val ParseOpsHFunctor: HFunctor[ParseOps] = new HFunctor[ParseOps] {
+    override def hfmap[M[_], N[_]](nt: M ~> N): ParseOps[M, ?] ~> ParseOps[N, ?] = {
+      new (ParseOps[M, ?] ~> ParseOps[N, ?]) {
+        override def apply[A](fa: ParseOps[M, A]): ParseOps[N, A] = {
+          fa match {
+            case g: GetNullable[M, a] with ParseOps[M, A] =>
+              // todo: can we avoid casting ?
+              GetNullable(nt(g.ops)).asInstanceOf[ParseOps[N, A]]
+
+            case getN: GetN[M, A]   => GetN(getN.n, nt(getN.next))
+            case getK: GetKey[M, A] => GetKey(getK.key, nt(getK.next))
+            case GetString          => GetString
+            case GetBool            => GetBool
+            case num: GetNum        => num
+          }
+        }
       }
     }
-
-    override def foldLeft[A, B](fa: ParseOps[A], b: B)(f: (B, A) => B): B = {
-      fa match {
-        case GetString      => b
-        case GetNum(_)      => b
-        case GetBool        => b
-        case GetNullable(a) => f(b, a)
-        case GetN(_, a)     => f(b, a)
-        case GetKey(_, a)   => f(b, a)
-      }
-    }
-
-    override def foldRight[A, B](fa: ParseOps[A], lb: Eval[B])(
-        f: (A, Eval[B]) => Eval[B]): Eval[B] = fa match {
-      case GetString      => lb
-      case GetNum(_)      => lb
-      case GetBool        => lb
-      case GetNullable(a) => f(a, lb)
-      case GetN(_, a)     => f(a, lb)
-      case GetKey(_, a)   => f(a, lb)
-    }
-  }
-
-  type ParseOpsF    = ParseOps[Fix[ParseOps]]
-  type StringEff[A] = Const[String, A]
-  implicit val showRecursiveOps: Show[ParseOpsF] = Show.show[ParseOpsF] {
-    case GetString => GetString.toString
-    case g: GetNum => g.toString
-    case GetBool   => GetBool.toString
-    case GetNullable(a) =>
-      s"""GetNullable {
-        |  ${showRecursiveOps.show(a.unfix)}
-        |}""".stripMargin
-    case GetN(n, a) =>
-      s"""
-         |GetN($n) {
-         |  ${showRecursiveOps.show(a.unfix)}
-         |}
-       """.stripMargin
-    case GetKey(k, a) =>
-      s"""
-         |GetKey($k) {
-         |  ${showRecursiveOps.show(a.unfix)}
-         |}
-       """.stripMargin
   }
 }

--- a/src/main/scala/basil/data/ParseOps.scala
+++ b/src/main/scala/basil/data/ParseOps.scala
@@ -5,6 +5,12 @@ import cats.syntax.functor._
 import cats.{Applicative, Eval, Show, Traverse}
 import schemes._
 
+/**
+  * Potentially recursive tree to represent data that's needed
+  * from json
+  *
+  * todo: support sequence
+  */
 sealed trait ParseOps[+A]
 
 case object GetString                       extends ParseOps[Nothing]

--- a/src/main/scala/basil/data/ParseOps.scala
+++ b/src/main/scala/basil/data/ParseOps.scala
@@ -9,13 +9,9 @@ import cats.~>
   * todo: support sequence
   */
 sealed trait ParseOps[+F[_], I]
-
-case object GetString                             extends ParseOps[Nothing, String]
-case object GetBool                               extends ParseOps[Nothing, Boolean]
-final case class GetNum(term: ExpectedTerminator) extends ParseOps[Nothing, Double]
-final case class GetNullable[F[_], I](ops: F[I]) extends ParseOps[F, Option[I]] {
-  def toG[G[_]](nt: F ~> G): GetNullable[G, I] = GetNullable(nt(ops))
-}
+case object GetString                                     extends ParseOps[Nothing, String]
+case object GetBool                                       extends ParseOps[Nothing, Boolean]
+final case class GetNum(term: ExpectedTerminator)         extends ParseOps[Nothing, Double]
 final case class GetN[F[_], I](n: Int, next: F[I])        extends ParseOps[F, I]
 final case class GetKey[F[_], I](key: String, next: F[I]) extends ParseOps[F, I]
 
@@ -25,10 +21,6 @@ object ParseOps {
       new (ParseOps[M, ?] ~> ParseOps[N, ?]) {
         override def apply[A](fa: ParseOps[M, A]): ParseOps[N, A] = {
           fa match {
-            case g: GetNullable[M, a] with ParseOps[M, A] =>
-              // todo: can we avoid casting ?
-              GetNullable(nt(g.ops)).asInstanceOf[ParseOps[N, A]]
-
             case getN: GetN[M, A]   => GetN(getN.n, nt(getN.next))
             case getK: GetKey[M, A] => GetKey(getK.key, nt(getK.next))
             case GetString          => GetString

--- a/src/main/scala/basil/data/ParseOpsConstructor.scala
+++ b/src/main/scala/basil/data/ParseOpsConstructor.scala
@@ -2,8 +2,15 @@ package basil.data
 
 import schemes.Fix
 
-trait ParseOpsConstructor {
-  implicit class ContinuableBy(c: Continuable[ParseOps]) {
+object ParseOpsConstructor {
+
+  /**
+    * Syntatic sugar to support creating nested ParseOps structure
+    * using builder pattern
+    *
+    * todo: how much overhead does this adds?
+    */
+  implicit class ContinuableBy(val c: Continuable[ParseOps]) extends AnyVal {
     def getKey(key: String): Continuable[ParseOps] = {
       val cont: Fix[ParseOps] => Fix[ParseOps] = { next =>
         Fix(GetKey(key, next))
@@ -44,5 +51,3 @@ sealed trait ExprTree[A[_]]
 case class Continuable[A[_]](cont: Fix[A] => Fix[A], terminator: ExpectedTerminator)
     extends ExprTree[A]
 case class ExprEnd[A[_]](t: Fix[A]) extends ExprTree[A]
-
-object ParseOpsConstructor extends ParseOpsConstructor

--- a/src/main/scala/basil/parser/JsonParse.scala
+++ b/src/main/scala/basil/parser/JsonParse.scala
@@ -149,7 +149,7 @@ abstract class JsonParse[Source[_], JVal](implicit TakeOne: TakeOne[Source],
     recurse(i)(Vector.empty, lastCharIsSpecial = false)
   }
 
-  def skipWS(s: CharSource): CharSource = {
+  private def skipWS(s: CharSource): CharSource = {
     s.take1.flatMap[Char] {
       case (whitespace(_), next) => skipWS(next)
       case (c, next)             => Cons.cons(next, c)
@@ -271,7 +271,7 @@ abstract class JsonParse[Source[_], JVal](implicit TakeOne: TakeOne[Source],
   private case class Part1(part1: Vector[Char], sep: Option[Char], cont: CharSource)
   private case class Part2(part2: Vector[Char], sep: Option[Char], cont: CharSource)
 
-  def consumeTillTermination[A](s: CharSource)(
+  private def consumeTillTermination[A](s: CharSource)(
       term: ExpectedTerminator,
       f: CharSource => Source[A])(implicit p: Vector[PPath]): Source[A] = {
     skipWS(s).take1.flatMap {

--- a/src/main/scala/basil/parser/Parser.scala
+++ b/src/main/scala/basil/parser/Parser.scala
@@ -1,7 +1,7 @@
 package basil.parser
 
 import basil.data._
-import schemes.{Fix, Schemes}
+import ParseOps.ParseOpsHFunctor
 
 object Parser {
 
@@ -15,9 +15,9 @@ object Parser {
     * @tparam JV User supplied Json AST type
     * @return
     */
-  def parseJS[Source[_], JV](expr: Fix[ParseOps], src: Source[Char])(
-      implicit parse: JsonParse[Source, JV]): Source[(JV, parse.CharSource)] = {
-    Schemes.cata(expr)(parse.parsing).apply(Vector.empty)(src)
+  def parseJS[Source[_], I](expr: HFix[ParseOps, I], src: Source[Char])(
+      implicit parse: JsonParse[Source]): Source[(I, parse.CharSource)] = {
+    HFix.cata[ParseOps, I, parse.Parse](expr, parse.parsing).apply(Vector.empty)(src)
   }
 }
 

--- a/src/main/scala/basil/parser/Parser.scala
+++ b/src/main/scala/basil/parser/Parser.scala
@@ -5,6 +5,16 @@ import schemes.{Fix, Schemes}
 
 object Parser {
 
+  /**
+    * The canonical entry point of this library, to extract certain
+    * piece of data from a data source
+    *
+    * @param expr The parse operations tree that describe data
+    *             user wanted
+    * @param src Data source
+    * @tparam JV User supplied Json AST type
+    * @return
+    */
   def parseJS[Source[_], JV](expr: Fix[ParseOps], src: Source[Char])(
       implicit parse: JsonParse[Source, JV]): Source[(JV, parse.CharSource)] = {
     Schemes.cata(expr)(parse.parsing).apply(Vector.empty)(src)

--- a/src/main/scala/basil/parser/implicits.scala
+++ b/src/main/scala/basil/parser/implicits.scala
@@ -4,9 +4,8 @@ import basil.typeclass.instances._
 import cats.effect.IO
 import cats.instances.list._
 import fs2.Stream
-import org.json4s.JsonAST.JValue
 
 object implicits {
-  implicit object ListJsonParser   extends JsonParse[TryList, JValue]
-  implicit object StreamJsonParser extends JsonParse[Stream[IO, ?], JValue]
+  implicit object ListJsonParser   extends JsonParse[TryList]
+  implicit object StreamJsonParser extends JsonParse[Stream[IO, ?]]
 }

--- a/src/main/scala/basil/typeclass/Cons.scala
+++ b/src/main/scala/basil/typeclass/Cons.scala
@@ -1,5 +1,11 @@
 package basil.typeclass
 
+/**
+  * Typeclass to provide capability of prepending an element into
+  * a source of element
+  *
+  * todo: Create laws for it with drop?
+  */
 trait Cons[Col[_]] {
   def cons[E](cols: Col[E], e: E): Col[E]
 }

--- a/src/main/scala/basil/typeclass/JsRepr.scala
+++ b/src/main/scala/basil/typeclass/JsRepr.scala
@@ -6,8 +6,6 @@ trait JsRepr[JVal] {
   type Str <: JVal
   type Num <: JVal
   type Bool <: JVal
-  type Arr <: JVal
-  type Obj <: JVal
   type Null <: JVal
 
   def str(s: String): Str
@@ -21,8 +19,6 @@ object JsRepr {
     override type Str  = JString
     override type Num  = JDouble
     override type Bool = JBool
-    override type Arr  = JArray
-    override type Obj  = JObject
     override type Null = JNull.type
 
     override def str(s: String): Str = JString(s)

--- a/src/main/scala/basil/typeclass/TakeOne.scala
+++ b/src/main/scala/basil/typeclass/TakeOne.scala
@@ -11,11 +11,46 @@ import cats.{Eq, Functor, Monad}
 
 import scala.util.{Success, Try}
 
+/**
+  * Typeclass to provide capability of taking 1 element from a data
+  * source
+  *
+  * User needs to implement 2 methods
+  *   - take1
+  *   - take1Opt
+  * @tparam Source
+  */
 trait TakeOne[Source[_]] {
+
+  /**
+    * takes an element from Source and return the Element with
+    * the rest of the Data without escaping the Source context
+    *
+    * It will return empty source if input source is empty,
+    * the emptiness is implied and not captured in part of the type
+    *
+    * essentially List[Int]() and List[String]() are equivalent
+    */
   def take1[Element](src: Source[Element]): Source[(Element, Source[Element])]
 
+  /**
+    * takes an element from Source and return the element with
+    * the rest of the Data
+    *
+    * It will return None and Empty source if input source is empty,
+    * the main difference of this method versus `take1` is that
+    * `take1Opt` allows caller to handle emptiness within Source
+    * context
+    *
+    * This is useful when you want to tranform empty Source into
+    * something else
+    */
   def take1Opt[Element](src: Source[Element]): Source[(Option[Element], Source[Element])]
 
+  /**
+    * returns the 1st element from the source without consuming
+    * the data source
+    */
   def peek1[Element](src: Source[Element])(
       implicit Functor: Functor[Source],
       cons: Cons[Source]): Source[(Element, Source[Element])] = {

--- a/src/test/scala/basil/parser/ListParserSpec.scala
+++ b/src/test/scala/basil/parser/ListParserSpec.scala
@@ -2,12 +2,11 @@ package basil.parser
 
 import basil.typeclass.instances._
 import cats.instances.list._
-import org.json4s.JValue
 
 import scala.util.Success
 
 class ListParserSpec extends ParseSpec[TryList] {
-  override implicit val parser: JsonParse[TryList, JValue] = implicits.ListJsonParser
+  override implicit val parser: JsonParse[TryList] = implicits.ListJsonParser
 
   override def liftF(charArr: Array[Char]): TryList[Char] = Success(List(charArr: _*))
 

--- a/src/test/scala/basil/parser/ParseSpec.scala
+++ b/src/test/scala/basil/parser/ParseSpec.scala
@@ -38,7 +38,7 @@ abstract class ParseSpec[F[_]: Functor]
         val jsonStr = pretty(render(js)).toCharArray
         val decoded = parseString(path)(liftF(jsonStr)).getVal
 
-        decoded mustBe js
+        decoded mustBe js.values
       }
     }
     "parse boolean" in new PContext[F] {
@@ -47,7 +47,7 @@ abstract class ParseSpec[F[_]: Functor]
         val jsonStr = pretty(render(js)).toCharArray
         val decoded = parseBoolean(path)(liftF(jsonStr)).getVal
 
-        decoded mustBe js
+        decoded mustBe js.value
       }
     }
     "parse number" in new PContext[F] {
@@ -55,7 +55,7 @@ abstract class ParseSpec[F[_]: Functor]
       forAll(jnumGen) { num =>
         val jsonStr = pretty(render(num)).toCharArray
         val decoded = parseNumber(End)(path)(liftF(jsonStr)).getVal
-        decoded mustBe num
+        decoded mustBe num.values
       }
     }
     "parse array" in new PContext[F] {
@@ -68,7 +68,7 @@ abstract class ParseSpec[F[_]: Functor]
           val decoded =
             parseArrayItem(i, parser.parseString)(path)(liftF(jsonStr)).getVal
 
-          decoded mustBe expected
+          decoded mustBe expected.values
       }
     }
     "parse object" in new PContext[F] {
@@ -78,7 +78,7 @@ abstract class ParseSpec[F[_]: Functor]
 
           val ops     = Start[String].getKey("myKey").getN(2).getString.t
           val decoded = parseJSStream(ops, liftF(jsonStr)).getVal
-          decoded mustBe expected
+          decoded mustBe expected.values
       }
     }
     "parse random JS" in new PContext[F] {
@@ -88,7 +88,7 @@ abstract class ParseSpec[F[_]: Functor]
 
           val decoded = parseJSStream(HFix(ops), liftF(jsStr)).getVal
 
-          decoded mustBe extracted
+          decoded mustBe extracted.values
       }
     }
     "parse partial array" in new PContext[F] {
@@ -98,7 +98,7 @@ abstract class ParseSpec[F[_]: Functor]
 
       val decoded = parseJSStream(ops, liftF(partialJsStr)).getVal
 
-      decoded mustBe JDouble(10)
+      decoded mustBe 10.0
     }
 
     "parse partial obj" in new PContext[F] {
@@ -112,7 +112,7 @@ abstract class ParseSpec[F[_]: Functor]
       val ops          = Start[String].getKey("").getKey("really?").getString.t
 
       val decoded = parseJSStream(ops, liftF(partialJsStr)).getVal
-      decoded mustBe JString("nope")
+      decoded mustBe "nope"
     }
   }
 }

--- a/src/test/scala/basil/parser/ParseSpec.scala
+++ b/src/test/scala/basil/parser/ParseSpec.scala
@@ -1,6 +1,7 @@
 package basil.parser
 
 import basil.data._
+import basil.data.ParseOpsConstructor._
 import cats.Functor
 import cats.syntax.functor._
 import org.json4s.JsonDSL._
@@ -15,11 +16,16 @@ abstract class ParseSpec[F[_]: Functor]
     extends WordSpec
     with MustMatchers
     with GeneratorDrivenPropertyChecks
-    with ParseOpsConstructor
     with ParserGen {
 
+  // JsonParse implementation to test
   implicit val parser: JsonParse[F, JValue]
+
+  // A way to lift char array to the Source effect for testing
   def liftF(charArr: Array[Char]): F[Char]
+
+  // get the last element from F[A], with the potential of
+  // throwing
   def getLast[A](f: F[A]): A
 
   private implicit class FOps[A](f: F[(JValue, A)]) {

--- a/src/test/scala/basil/parser/StreamParserSpec.scala
+++ b/src/test/scala/basil/parser/StreamParserSpec.scala
@@ -2,10 +2,9 @@ package basil.parser
 
 import cats.effect.IO
 import fs2.Stream
-import org.json4s._
 
 class StreamParserSpec extends ParseSpec[Stream[IO, ?]] {
-  override implicit val parser: JsonParse[Stream[IO, ?], JValue] = implicits.StreamJsonParser
+  override implicit val parser: JsonParse[Stream[IO, ?]] = implicits.StreamJsonParser
 
   override def liftF(charArr: Array[Char]): Stream[IO, Char] = Stream(charArr: _*)
 


### PR DESCRIPTION
The technique is from xenomorph

Consequently, I drop the support of `optional` in ParseOps, as now it is not very valuable, but impose some challenges in the implementation, the core issue is that `GetNullable` changes the type of the result type from `I => Option[I]`, and the fact that it can nest means we can potential get result of `Some(Some(Some(None)))`